### PR TITLE
Update username regex to fix issue #2

### DIFF
--- a/src/conf-sample/regex.yml
+++ b/src/conf-sample/regex.yml
@@ -1,6 +1,6 @@
 values:
     username:
-        regex: '(@\w+)'
+        regex: '(@[\w-]{3,20})'
     amount:
         regex: '([0-9]{1,9}(?:\.[0-9]{0,16})?)'
     tip_init:


### PR DESCRIPTION
Modified the regex to include a dash.

I also added the 3-20 length constraint since you can't register usernames shorter than 3 and longer than 20.
