### PR TITLE
Update altcointip for newer dependencies and general bug fixes

### DIFF
--- a/src/_start.sh
+++ b/src/_start.sh
@@ -2,7 +2,7 @@
 
 user=$1
 
-if [ ! -f ./cointipbot.py ] ; then
+if [ ! -f ./main.py ] ; then
 	# Output help message and exit
 	echo "Usage: $0 [username]"
 	echo "if [username] is specified, script will be started as user [username]"
@@ -12,8 +12,8 @@ fi
 
 if [ -z "$user" ] ; then
 	# Run as current user
-	python -c 'import cointipbot; cb=cointipbot.CointipBot(); cb.main()'
+	python -c 'import main; main=main.Main(); main.main()'
 else
 	# Run as $user
-	sudo su - $user -c "cd `pwd` && python -c 'import cointipbot; cb=cointipbot.CointipBot(); cb.main()'"
+	sudo su - $user -c "cd `pwd` && python -c 'import main; main=main.Main(); main.main()'"
 fi

--- a/src/cointipbot.py
+++ b/src/cointipbot.py
@@ -23,13 +23,12 @@ from email.mime.text import MIMEText
 from jinja2 import Environment, PackageLoader
 
 from requests.exceptions import HTTPError, ConnectionError, Timeout
-from praw.errors import ExceptionList, APIException, InvalidCaptcha, InvalidUser, RateLimitExceeded
+from praw.exceptions import APIException, ClientException
 from socket import timeout
 
 # Configure CointipBot logger
 logging.basicConfig()
 lg = logging.getLogger('cointipbot')
-
 
 class CointipBot(object):
     """
@@ -121,8 +120,13 @@ class CointipBot(object):
         """
         lg.debug('CointipBot::connect_reddit(): connecting to Reddit...')
 
-        conn = praw.Reddit(user_agent = self.conf.reddit.auth.user)
-        conn.login(self.conf.reddit.auth.user, self.conf.reddit.auth.password)
+        conn = praw.Reddit(
+            user_agent = self.conf.reddit.auth.user, 
+            client_id = self.conf.reddit.auth.client_id, 
+            client_secret = self.conf.reddit.auth.client_secret,
+            username = self.conf.reddit.auth.user,
+            password = self.conf.reddit.auth.password
+        )
 
         lg.info("CointipBot::connect_reddit(): logged in to Reddit as %s", self.conf.reddit.auth.user)
         return conn
@@ -192,7 +196,7 @@ class CointipBot(object):
         try:
 
             # Try to fetch some messages
-            messages = list(ctb_misc.praw_call(self.reddit.get_unread, limit=self.conf.reddit.scan.batch_limit))
+            messages = list(ctb_misc.praw_call(self.reddit.inbox.unread, limit=self.conf.reddit.scan.batch_limit))
             messages.reverse()
 
             # Process messages
@@ -200,7 +204,7 @@ class CointipBot(object):
                 # Sometimes messages don't have an author (such as 'you are banned from' message)
                 if not m.author:
                     lg.info("CointipBot::check_inbox(): ignoring msg with no author")
-                    ctb_misc.praw_call(m.mark_as_read)
+                    ctb_misc.praw_call(m.mark_read)
                     continue
 
                 lg.info("CointipBot::check_inbox(): %s from %s", "comment" if m.was_comment else "message", m.author.name)
@@ -208,13 +212,13 @@ class CointipBot(object):
                 # Ignore duplicate messages (sometimes Reddit fails to mark messages as read)
                 if ctb_action.check_action(msg_id=m.id, ctb=self):
                     lg.warning("CointipBot::check_inbox(): duplicate action detected (msg.id %s), ignoring", m.id)
-                    ctb_misc.praw_call(m.mark_as_read)
+                    ctb_misc.praw_call(m.mark_read)
                     continue
 
                 # Ignore self messages
                 if m.author and m.author.name.lower() == self.conf.reddit.auth.user.lower():
                     lg.debug("CointipBot::check_inbox(): ignoring message from self")
-                    ctb_misc.praw_call(m.mark_as_read)
+                    ctb_misc.praw_call(m.mark_read)
                     continue
 
                 # Ignore messages from banned users
@@ -223,7 +227,7 @@ class CointipBot(object):
                     u = ctb_user.CtbUser(name = m.author.name, redditobj = m.author, ctb = self)
                     if u.banned:
                         lg.info("CointipBot::check_inbox(): ignoring banned user '%s'" % m.author)
-                        ctb_misc.praw_call(m.mark_as_read)
+                        ctb_misc.praw_call(m.mark_read)
                         continue
 
                 action = None
@@ -249,17 +253,12 @@ class CointipBot(object):
                         user.tell(subj='What?', msg=msg, msgobj=m if not m.was_comment else None)
 
                 # Mark message as read
-                ctb_misc.praw_call(m.mark_as_read)
+                ctb_misc.praw_call(m.mark_read)
 
         except (HTTPError, ConnectionError, Timeout, timeout) as e:
             lg.warning("CointipBot::check_inbox(): Reddit is down (%s), sleeping", e)
             time.sleep(self.conf.misc.times.sleep_seconds)
             pass
-        except RateLimitExceeded as e:
-             lg.warning("CointipBot::check_inbox(): rate limit exceeded, sleeping for %s seconds", e.sleep_time) 
-             time.sleep(e.sleep_time)
-             time.sleep(1)
-             pass
         except Exception as e:
             lg.error("CointipBot::check_inbox(): %s", e)
             raise
@@ -285,7 +284,7 @@ class CointipBot(object):
 
                 elif self.conf.reddit.scan.my_subreddits:
                     # Subreddits are subscribed to by bot user
-                    my_reddits = ctb_misc.praw_call(self.reddit.get_my_subreddits, limit=None)
+                    my_reddits = ctb_misc.praw_call(self.reddit.user.subreddits, limit=None)
                     my_reddits_list = []
                     for my_reddit in my_reddits:
                         my_reddits_list.append(my_reddit.display_name.lower())
@@ -301,7 +300,7 @@ class CointipBot(object):
 
                 # Get multi-reddit PRAW object
                 lg.debug("CointipBot::check_subreddits(): multi-reddit string: %s", my_reddits_string)
-                self.conf.reddit.subreddits = ctb_misc.praw_call(self.reddit.get_subreddit, my_reddits_string)
+                self.conf.reddit.subreddits = ctb_misc.praw_call(self.reddit.subreddit, my_reddits_string)
 
         except Exception as e:
             lg.error("CointipBot::check_subreddits(): coudln't get subreddits: %s", e)
@@ -367,7 +366,7 @@ class CointipBot(object):
             if counter >= self.conf.reddit.scan.batch_limit - 1:
                 lg.warning("CointipBot::check_subreddits(): conf.reddit.scan.batch_limit (%s) was not large enough to process all comments", self.conf.reddit.scan.batch_limit)
 
-        except (HTTPError, RateLimitExceeded, timeout) as e:
+        except (HTTPError, timeout) as e:
             lg.warning("CointipBot::check_subreddits(): Reddit is down (%s), sleeping", e)
             time.sleep(self.conf.misc.times.sleep_seconds)
             pass
@@ -394,6 +393,32 @@ class CointipBot(object):
             lg.debug("< CointipBot::refresh_ev(): DONE (skipping)")
             return
 
+         # For each enabled fiat...
+        for f in vars(self.conf.fiat):
+            if self.conf.fiat[f].enabled:
+
+                # Get fiat/BTC exchange rate
+                values = []
+                result = 0.0
+
+                # For each exchange that supports this fiat...
+                for e in self.exchanges:
+                    if self.exchanges[e].supports_pair(_name1='btc', _name2=self.conf.fiat[f].unit):
+                        # Get ticker value from exchange
+                        value = self.exchanges[e].get_ticker_value(_name1='btc', _longname1='bitcoin', _name2=self.conf.fiat[f].unit)
+                        if value and float(value) > 0.0:
+                            values.append(float(value))
+
+                # Result is average of all responses
+                if len(values) > 0:
+                    result = sum(values) / float(len(values))
+
+                # Assign result to self.runtime['ev']
+                if not self.runtime['ev'].has_key('btc'):
+                    self.runtime['ev']['btc'] = {}
+
+                self.runtime['ev']['btc'][f] = result
+
         # For each enabled coin...
         for c in vars(self.conf.coins):
             if self.conf.coins[c].enabled:
@@ -407,7 +432,7 @@ class CointipBot(object):
                     for e in self.exchanges:
                         if self.exchanges[e].supports_pair(_name1=self.conf.coins[c].unit, _name2='btc'):
                             # Get ticker value from exchange
-                            value = self.exchanges[e].get_ticker_value(_name1=self.conf.coins[c].unit, _name2='btc')
+                            value = self.exchanges[e].get_ticker_value(_name1=self.conf.coins[c].unit, _longname1=self.conf.coins[c].name.lower(), _name2='btc')
                             if value and float(value) > 0.0:
                                 values.append(float(value))
 
@@ -422,32 +447,13 @@ class CointipBot(object):
                 # Assign result to self.runtime['ev']
                 if not self.runtime['ev'].has_key(c):
                     self.runtime['ev'][c] = {}
+
                 self.runtime['ev'][c]['btc'] = result
 
-        # For each enabled fiat...
-        for f in vars(self.conf.fiat):
-            if self.conf.fiat[f].enabled:
-
-                # Get fiat/BTC exchange rate
-                values = []
-                result = 0.0
-
-                # For each exchange that supports this fiat...
-                for e in self.exchanges:
-                    if self.exchanges[e].supports_pair(_name1='btc', _name2=self.conf.fiat[f].unit):
-                        # Get ticker value from exchange
-                        value = self.exchanges[e].get_ticker_value(_name1='btc', _name2=self.conf.fiat[f].unit)
-                        if value and float(value) > 0.0:
-                            values.append(float(value))
-
-                # Result is average of all responses
-                if len(values) > 0:
-                    result = sum(values) / float(len(values))
-
-                # Assign result to self.runtime['ev']
-                if not self.runtime['ev'].has_key('btc'):
-                    self.runtime['ev']['btc'] = {}
-                self.runtime['ev']['btc'][f] = result
+                # For each enabled fiat...
+                for f in vars(self.conf.fiat):
+                    if self.conf.fiat[f].enabled:
+                        self.runtime['ev'][c][f] = self.runtime['ev']['btc'][f] * self.runtime['ev'][c]['btc']
 
         lg.debug("CointipBot::refresh_ev(): %s", self.runtime['ev'])
 
@@ -574,15 +580,3 @@ class CointipBot(object):
             if self.conf.misc.notify.enabled:
                 self.notify(_msg=tb)
             sys.exit(1)
-				
-    def secondary():
-	try:
-	   while True:
-		main(self)
-	except:
-	    traceback.print_exc()
-	    print('Resuming in 30sec...')
-	    time.sleep(30)
-	    print('Resumed')
-while True:
-	secondary()

--- a/src/cointipbot.py
+++ b/src/cointipbot.py
@@ -86,7 +86,11 @@ class CointipBot(object):
             prefix='./conf/'
             for i in ['coins', 'db', 'exchanges', 'fiat', 'keywords', 'logs', 'misc', 'reddit', 'regex']:
                 lg.debug("CointipBot::parse_config(): reading %s%s.yml", prefix, i)
-                conf[i] = yaml.load(open(prefix+i+'.yml'))
+
+                file = open(prefix + i + '.yml')
+                conf[i] = yaml.load(file)
+
+                file.close()
         except yaml.YAMLError as e:
             lg.error("CointipBot::parse_config(): error reading config file: %s", e)
             if hasattr(e, 'problem_mark'):

--- a/src/conf-sample/db.yml
+++ b/src/conf-sample/db.yml
@@ -11,17 +11,17 @@ sql:
       name: "Total Accepted Tips (USD)"
       desc: "Total value of all tips given and accepted in USD (default) fiat"
       type: line
-      query: "SELECT SUM(fiat_val) AS total_usd, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat = 'usd'"
+      query: "SELECT SUM(fiat_val) AS total_usd, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat = 'usd' GROUP BY fiat"
     01a_total_tipped_usd_by_coin:
       name: "Total Accepted Tips (USD) By Coin"
       desc: "Total value of all tips given and accepted in USD (default) fiat grouped by coin"
       type: table
-      query: "SELECT coin, SUM(fiat_val) AS total_usd, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat = 'usd' GROUP BY coin ORDER BY coin"
+      query: "SELECT coin, SUM(fiat_val) AS total_usd, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat = 'usd' GROUP BY coin, fiat ORDER BY coin"
     02_total_tips_expired_and_declined:
       name: "Total Expired and Declined Tips (USD)"
       desc: "Total value of all tips given that weren't accepted (expired or declined) in USD (default) fiat"
       type: line
-      query: "SELECT SUM(fiat_val) AS total_usd, fiat FROM t_action WHERE type = 'givetip' AND state = 'expired' OR state = 'declined' AND fiat = 'usd'"
+      query: "SELECT SUM(fiat_val) AS total_usd, fiat FROM t_action WHERE type = 'givetip' AND (state = 'expired' OR state = 'declined') AND fiat = 'usd' GROUP BY fiat"
     03_total_users_registered:
       name: "Total Users Registered"
       desc: "Number of registered users"
@@ -51,7 +51,7 @@ sql:
       name: "Top 10 Tippers"
       desc: "Top 10 all-time tippers as determined by total USD/EUR (fiat) value of their tips."
       type: table
-      query: "SELECT from_user, SUM(fiat_val) AS total_fiat, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat IN ('usd', 'eur') GROUP BY from_user ORDER BY total_fiat DESC LIMIT 10"
+      query: "SELECT from_user, SUM(fiat_val) AS total_fiat, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat IN ('usd', 'eur') GROUP BY from_user, fiat ORDER BY total_fiat DESC LIMIT 10"
     07_top_10_tips:
       name: "Top 10 Tips"
       desc: "Top 10 all-time tips as determined by their USD/EUR (fiat) value."
@@ -91,7 +91,7 @@ sql:
       name: "Top 10 Receivers"
       desc: "Top 10 all-time tip receivers as determined by total USD/EUR (fiat) value of their received tips."
       type: table
-      query: "SELECT to_user, SUM(fiat_val) AS total_fiat, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat IN ('usd', 'eur') AND to_user IS NOT NULL GROUP BY to_user ORDER BY total_fiat DESC LIMIT 10"
+      query: "SELECT to_user, SUM(fiat_val) AS total_fiat, fiat FROM t_action WHERE type = 'givetip' AND state = 'completed' AND fiat IN ('usd', 'eur') AND to_user IS NOT NULL GROUP BY to_user, fiat ORDER BY total_fiat DESC LIMIT 10"
   userstats:
     users: "SELECT username FROM t_users WHERE username IN (SELECT from_user FROM t_action WHERE type = 'givetip') OR username in (SELECT to_user FROM t_action WHERE type = 'givetip') ORDER BY username"
     coins: 'SELECT DISTINCT coin FROM t_action WHERE coin IS NOT NULL ORDER BY coin'

--- a/src/conf-sample/exchanges.yml
+++ b/src/conf-sample/exchanges.yml
@@ -107,3 +107,14 @@ cryptocoincharts:
     coinlist: ['btc','ltc','ppc','nmc','xmp','mec','bqc','dgc','ifc','ixc','mnc','qrk','sbc','zet','doge','nxt','msc','ftc','nvc','dvc','frc','trc']
     fiatlist: ['usd','eur']
     uppercase: false
+
+coinmarketcap:
+    enabled: true
+    domain: 'api.coinmarketcap.com'
+    https: true
+    urlpaths: ['/v1/ticker/{THING_FROM}/?convert={THING_TO}']
+    jsonpaths: ['0.price_{THING_TO}']
+    coinlist: ['dgb','btc']
+    fiatlist: ['usd','eur']
+    uppercase: false
+    longname: true

--- a/src/conf-sample/exchanges.yml
+++ b/src/conf-sample/exchanges.yml
@@ -7,6 +7,7 @@ blockchaininfo:
     coinlist: ['btc']
     fiatlist: ['usd','cny','jpy','sgd','hkd','cad','aud','nzd','gbp','dkk','sek','brl','chf','eur','rub','sll','pln','thb']
     uppercase: true
+    longname: false
 
 vircurex:
     enabled: true
@@ -17,6 +18,7 @@ vircurex:
     coinlist: ['anc','btc','dgc','dvc','frc','ftc','i0c','ixc','ltc','nmc','nvc','ppc','trc','xpm']
     fiatlist: ['usd','eur']
     uppercase: true
+    longname: false
 
 btce:
     enabled: true
@@ -27,6 +29,7 @@ btce:
     coinlist: ['btc','ltc','nmc','nvc','trc','ppc','ftc','xpm']
     fiatlist: ['usd','eur','rur']
     uppercase: false
+    longname: false
 
 bitstamp:
     enabled: true
@@ -37,6 +40,7 @@ bitstamp:
     coinlist: ['btc']
     fiatlist: ['usd']
     uppercase: false
+    longname: false
 
 mtgox:
     enabled: false
@@ -47,6 +51,7 @@ mtgox:
     coinlist: ['btc']
     fiatlist: ['usd','eur','jpy','gbp','rub']
     uppercase: true
+    longname: false
 
 campbx:
     enabled: true
@@ -57,6 +62,7 @@ campbx:
     coinlist: ['btc']
     fiatlist: ['usd']
     uppercase: false
+    longname: false
 
 cryptsy:
     enabled: true
@@ -67,6 +73,7 @@ cryptsy:
     coinlist: ['btc','alf','amc','anc','arg','bqc','bte','btg','buk','cap','cgb','clr','cmc','crc','csc','dgc','dmd','elc','emd','frc','frk','fst','ftc','gdc','glc','glx','hbn','ixc','kgc','lk7','lky','ltc','mec','mnc','nbl','nec','nmc','nrb','nvc','phs','ppc','pts','pxc','pyc','qrk','sbc','spt','src','tag','tek','trc','wdc','xjo','xpm','yac','zet']
     fiatlist: []
     uppercase: true
+    longname: false
 
 bter:
     enabled: true
@@ -77,6 +84,7 @@ bter:
     coinlist: ['btc','ltc','ppc','frc','ftc','cnc','bqc','btb','wdc','yac','xpm','pts','zcc','dtc','red','cent','zet','src','mec','qrk']
     fiatlist: ['cny']
     uppercase: false
+    longname: false
 
 cryptotrade:
     enabled: true
@@ -87,6 +95,7 @@ cryptotrade:
     coinlist: ['btc','ltc','nmc','xpm','ppc','trc','ftc','dvc','wdc','dgc']
     fiatlist: ['usd','eur']
     uppercase: false
+    longname: false
 
 coinse:
     enabled: true
@@ -97,6 +106,7 @@ coinse:
     coinlist: ['btc','alp','amc','anc','bet','bqc','cgb','cin','crc','dem','dtc','elc','elp','emd','frk','ftc','gdc','glc','kgc','ltc','mec','nan','net','nrb','nvc','orb','ppc','pts','qrk','rec','red','spt','tag','trc','uno','wdc','xnc','xpm','zet']
     fiatlist: []
     uppercase: true
+    longname: false
 
 cryptocoincharts:
     enabled: true
@@ -107,6 +117,7 @@ cryptocoincharts:
     coinlist: ['btc','ltc','ppc','nmc','xmp','mec','bqc','dgc','ifc','ixc','mnc','qrk','sbc','zet','doge','nxt','msc','ftc','nvc','dvc','frc','trc']
     fiatlist: ['usd','eur']
     uppercase: false
+    longname: false
 
 coinmarketcap:
     enabled: true

--- a/src/conf-sample/reddit.yml
+++ b/src/conf-sample/reddit.yml
@@ -1,6 +1,8 @@
 auth:
     user: 'mybotuser'
     password: 'mybotpass'
+    client_id: 'abcdefg'
+    client_secret: 'supersecretsecret'
 
 scan:
     batch_limit: 1000

--- a/src/ctb/ctb_action.py
+++ b/src/ctb/ctb_action.py
@@ -1251,7 +1251,7 @@ def get_actions(atype=None, state=None, coin=None, msg_id=None, created_utc=None
                 # Get PRAW message/comment pointer (msg)
                 msg = None
                 if m['msg_link']:
-                    submission = ctb_misc.praw_call(ctb.reddit.get_submission, m['msg_link'])
+                    submission = ctb_misc.praw_call(ctb.reddit.submission, m['msg_link'])
                     if not len(submission.comments) > 0:
                         lg.warning("get_actions(): could not fetch msg (deleted?) from msg_link %s", m['msg_link'])
                     else:

--- a/src/ctb/ctb_action.py
+++ b/src/ctb/ctb_action.py
@@ -870,19 +870,26 @@ class CtbAction(object):
         rates = {}
 
         # Get exchange rates
-        for coin in self.ctb.coins:
+        for c in vars(self.ctb.conf.coins):
+            if (not self.ctb.conf.coins[c].enabled) and self.ctb.conf.coins[c].unit != 'btc':
+                continue;
+
+            coin = self.ctb.conf.coins[c].unit.lower()
+            longcoin = self.ctb.conf.coins[c].name.lower()
+
             coins.append(coin)
             rates[coin] = {'average': {}}
             rates[coin]['average']['btc'] = self.ctb.runtime['ev'][coin]['btc']
             rates[coin]['average'][fiat] = self.ctb.runtime['ev'][coin]['btc'] * self.ctb.runtime['ev']['btc'][fiat]
+
             for exchange in self.ctb.exchanges:
                 try:
                     rates[coin][exchange] = {}
                     if self.ctb.exchanges[exchange].supports_pair(_name1=coin, _name2='btc'):
-                        rates[coin][exchange]['btc'] = self.ctb.exchanges[exchange].get_ticker_value(_name1=coin, _name2='btc')
+                        rates[coin][exchange]['btc'] = self.ctb.exchanges[exchange].get_ticker_value(_name1=coin, _longname1=longcoin, _name2='btc')
                         if coin == 'btc' and self.ctb.exchanges[exchange].supports_pair(_name1='btc', _name2=fiat):
                             # Use exchange value to calculate btc's fiat value
-                            rates[coin][exchange][fiat] = rates[coin][exchange]['btc'] * self.ctb.exchanges[exchange].get_ticker_value(_name1='btc', _name2=fiat)
+                            rates[coin][exchange][fiat] = rates[coin][exchange]['btc'] * self.ctb.exchanges[exchange].get_ticker_value(_name1='btc', _longname1='bitcoin', _name2=fiat)
                         else:
                             # Use average value to calculate coin's fiat value
                             rates[coin][exchange][fiat] = rates[coin][exchange]['btc'] * self.ctb.runtime['ev']['btc'][fiat]

--- a/src/ctb/ctb_action.py
+++ b/src/ctb/ctb_action.py
@@ -871,7 +871,7 @@ class CtbAction(object):
 
         # Get exchange rates
         for c in vars(self.ctb.conf.coins):
-            if (not self.ctb.conf.coins[c].enabled) and self.ctb.conf.coins[c].unit != 'btc':
+            if not self.ctb.conf.coins[c].enabled:
                 continue;
 
             coin = self.ctb.conf.coins[c].unit.lower()

--- a/src/ctb/ctb_exchange.py
+++ b/src/ctb/ctb_exchange.py
@@ -67,7 +67,7 @@ class CtbExchange(object):
 
         return self.supports(_name=_name1) and self.supports(_name=_name2)
 
-    def get_ticker_value(self, _name1 = None, _name2 = None):
+    def get_ticker_value(self, _name1 = None, _longname1 = None, _name2 = None):
         """
         Return (float) ticker value for given pair
         """
@@ -77,6 +77,9 @@ class CtbExchange(object):
 
         if not self.supports_pair(_name1=_name1, _name2=_name2):
             raise Exception("CtbExchange::get_ticker_value(%s, %s, %s): pair not supported" % (self.conf.domain, _name1, _name2))
+
+        if self.conf.longname:
+            _name1 = _longname1
 
         results = []
         for myurlpath in self.conf.urlpaths:

--- a/src/ctb/ctb_misc.py
+++ b/src/ctb/ctb_misc.py
@@ -20,7 +20,7 @@ import ctb_user
 import logging, time
 
 from requests.exceptions import HTTPError, ConnectionError, Timeout
-from praw.errors import ExceptionList, APIException, InvalidCaptcha, InvalidUser, RateLimitExceeded
+from praw.exceptions import APIException, ClientException
 from socket import timeout
 
 lg = logging.getLogger('cointipbot')
@@ -46,17 +46,6 @@ def praw_call(prawFunc, *extraArgs, **extraKwArgs):
                 lg.warning("praw_call(): Reddit returned error (%s), sleeping...", e)
                 time.sleep(30)
                 pass
-        except APIException as e:
-            if str(e) == "(DELETED_COMMENT) `that comment has been deleted` on field `parent`":
-                lg.warning("praw_call(): deleted comment: %s", e)
-                return False
-            else:
-                raise
-        except RateLimitExceeded as e:
-            lg.warning("praw_call(): rate limit exceeded, sleeping for %s seconds", e.sleep_time)
-            time.sleep(e.sleep_time)
-            time.sleep(1)
-            pass
         except Exception as e:
             raise
 
@@ -93,10 +82,10 @@ def reddit_get_parent_author(comment, reddit, ctb):
                 lg.warning("< reddit_get_parent_author(%s) -> NONE", comment.id)
                 return None
 
-        except (IndexError, APIException, AttributeError) as e:
+        except (IndexError, AttributeError) as e:
             lg.warning("reddit_get_parent_author(): couldn't get author: %s", e)
             return None
-        except (HTTPError, RateLimitExceeded, timeout) as e:
+        except (HTTPError, timeout) as e:
             if str(e) in [ "400 Client Error: Bad Request", "403 Client Error: Forbidden", "404 Client Error: Not Found" ]:
                 lg.warning("reddit_get_parent_author(): Reddit returned error (%s)", e)
                 return None

--- a/src/ctb/ctb_misc.py
+++ b/src/ctb/ctb_misc.py
@@ -60,20 +60,8 @@ def reddit_get_parent_author(comment, reddit, ctb):
     while True:
 
         try:
-
-            parentpermalink = comment.permalink.replace(comment.id, comment.parent_id[3:])
-            commentlinkid = None
-            if hasattr(comment, 'link_id'):
-                commentlinkid = comment.link_id[3:]
-            else:
-                comment2 = reddit.get_submission(comment.permalink).comments[0]
-                commentlinkid = comment2.link_id[3:]
-            parentid = comment.parent_id[3:]
-
-            if commentlinkid == parentid:
-                parentcomment = reddit.get_submission(parentpermalink)
-            else:
-                parentcomment = reddit.get_submission(parentpermalink).comments[0]
+            comment = praw_call(ctb.reddit.comment, comment)
+            parentcomment = praw_call(comment.parent)
 
             if parentcomment and hasattr(parentcomment, 'author') and parentcomment.author:
                 lg.debug("< reddit_get_parent_author(%s) -> %s", comment.id, parentcomment.author.name)

--- a/src/ctb/ctb_stats.py
+++ b/src/ctb/ctb_stats.py
@@ -66,7 +66,11 @@ def update_stats(ctb=None):
         stats += "\n"
 
     lg.debug("update_stats(): updating subreddit '%s', page '%s'" % (ctb.conf.reddit.stats.subreddit, ctb.conf.reddit.stats.page))
-    return ctb_misc.praw_call(ctb.reddit.edit_wiki_page, ctb.conf.reddit.stats.subreddit, ctb.conf.reddit.stats.page, stats, "Update by ALTcointip bot")
+    
+    w = ctb_misc.praw_call(ctb.reddit.subreddit, ctb.conf.reddit.stats.subreddit).wiki
+    wp = ctb_misc.praw_call(w.__getitem__, ctb.conf.reddit.stats.page)
+
+    return ctb_misc.praw_call(wp.edit, stats, "Update by ALTcointip bot")
 
 def update_tips(ctb=None):
     """
@@ -92,8 +96,11 @@ def update_tips(ctb=None):
         tip_list += ("|".join(values)) + "\n"
 
     lg.debug("update_tips(): updating subreddit '%s', page '%s'" % (ctb.conf.reddit.stats.subreddit, ctb.conf.reddit.stats.page_tips))
-    ctb_misc.praw_call(ctb.reddit.edit_wiki_page, ctb.conf.reddit.stats.subreddit, ctb.conf.reddit.stats.page_tips, tip_list, "Update by ALTcointip bot")
+    
+    w = ctb_misc.praw_call(ctb.reddit.subreddit, ctb.conf.reddit.stats.subreddit).wiki
+    wp = ctb_misc.praw_call(w.__getitem__, ctb.conf.reddit.stats.page_tips)
 
+    ctb_misc.praw_call(wp.edit, tip_list, "Update by ALTcointip bot")
     return True
 
 def update_all_user_stats(ctb=None):
@@ -197,7 +204,11 @@ def update_user_stats(ctb=None, username=None):
 
     # Submit changes
     lg.debug("update_user_stats(): updating subreddit '%s', page '%s'" % (ctb.conf.reddit.stats.subreddit, page))
-    ctb_misc.praw_call(ctb.reddit.edit_wiki_page, ctb.conf.reddit.stats.subreddit, page, user_stats, "Update by ALTcointip bot")
+    
+    w = ctb_misc.praw_call(ctb.reddit.subreddit, ctb.conf.reddit.stats.subreddit).wiki
+    wp = ctb_misc.praw_call(w.__getitem__, page)
+
+    ctb_misc.praw_call(wp.edit, user_stats, "Update by ALTcointip bot")
 
     # Update user flair on subreddit
     if ctb.conf.reddit.stats.userflair and ( len(total_tipped) > 0 or len(total_received) > 0 ):
@@ -211,8 +222,8 @@ def update_user_stats(ctb=None, username=None):
             flair += "received[" + '|'.join(total_received) + "]"
             flair += " (%d)" % num_received
         lg.debug("update_user_stats(): updating flair for %s (%s)", username, flair)
-        r = ctb_misc.praw_call(ctb.reddit.get_subreddit, ctb.conf.reddit.stats.subreddit)
-        res = ctb_misc.praw_call(r.set_flair, username, flair, '')
+        r = ctb_misc.praw_call(ctb.reddit.subreddit, ctb.conf.reddit.stats.subreddit)
+        res = ctb_misc.praw_call(r.flair.set, username, flair, '')
         lg.debug(res)
 
     return True

--- a/src/ctb/ctb_user.py
+++ b/src/ctb/ctb_user.py
@@ -127,7 +127,7 @@ class CtbUser(object):
             return True
 
         try:
-            self.prawobj = ctb_misc.praw_call(self.ctb.reddit.get_redditor, self.name)
+            self.prawobj = ctb_misc.praw_call(self.ctb.reddit.redditor, self.name)
             if self.prawobj:
                 return True
             else:
@@ -203,7 +203,7 @@ class CtbUser(object):
             ctb_misc.praw_call(msgobj.reply, msg)
         else:
             lg.debug("CtbUser::tell(%s): sending message", self.name)
-            ctb_misc.praw_call(self.prawobj.send_message, subj, msg)
+            ctb_misc.praw_call(self.prawobj.message, subj, msg)
 
         lg.debug("< CtbUser::tell(%s) DONE", self.name)
         return True

--- a/src/main.py
+++ b/src/main.py
@@ -4,9 +4,20 @@ class Main():
     cb = None
 
     def __init__(self):
-        self.cb = cointipbot.CointipBot()
+        '''
+        Unfortunately, we cannot instantiate CointipBot only once due to the way pifkoin works. 
+
+        Pifkoin will open an HTTP connection to the RPC client which will eventually close when the bot completes its checks. Therefore, if we try to loop
+        CointipBot.main() without reinstanting the object, httplib will throw BadStatusLine because the connection is no longer valid and cannot be used.
+
+        May make a pull request to pifkoin to resolve this. If this does get resolved in pifkoin or you locally modify your pifkoin copy to resolve this, you can
+        uncomment the following line and comment the self.cb assignment in main(). This will ensure we do not need to reinstantiate CoinbotTip in every iteration.
+        '''
+        # self.cb = cointipbot.CointipBot()
 
     def main(self):
+        self.cb = cointipbot.CointipBot()
+
         self.cb.main()
 
 def secondary(main):

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,22 @@
+import cointipbot, traceback, time
+
+class Main():
+	def main(self):
+		cb = cointipbot.CointipBot();
+
+		cb.main();
+
+def secondary(main):
+    try:
+        while True:
+            main.main();
+    except:
+        traceback.print_exc()
+        print('Resuming in 7 seconds')
+        time.sleep(7)
+        print('Resumed')
+
+while True:
+    main = Main()
+
+    secondary(main)

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,13 @@
 import cointipbot, traceback, time
 
 class Main():
-    def main(self):
-        cb = cointipbot.CointipBot();
+    cb = None
 
-        cb.main();
+    def __init__(self):
+        self.cb = cointipbot.CointipBot()
+
+    def main(self):
+        self.cb.main()
 
 def secondary(main):
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,10 @@
 import cointipbot, traceback, time
 
 class Main():
-	def main(self):
-		cb = cointipbot.CointipBot();
+    def main(self):
+        cb = cointipbot.CointipBot();
 
-		cb.main();
+        cb.main();
 
 def secondary(main):
     try:


### PR DESCRIPTION
altcointip is not functional in its current state when using latest packages. For example, many of the PRAW functions such as "get_unread" do not exist.

This change does the following:
- Updates PRAW calls as of the [latest 5.4.0 docs](https://praw.readthedocs.io/en/latest/).
  - **This involves changing the authentication to OAuth using reddit apps.**
- Removes procedural loops from cointipbot.py and puts them in main.py
  - This resolves issues when attempting to run _update_stats.py or other scripts wherein the entire bot would be launched due to the loops that were at the bottom of cointipbot.py.
  - Without this change, there are indentation issues (mixed tabs and spaces) in the existing block added by #45 which causes the build to fail.
  - Still maintains functionality wherein the bot will restart upon crashing or exiting.
- Updates _start.sh to now call the new class Main from the main.py file.
- Adds coinmarketcap to the sample config exchanges.
  - Updates refresh_ev(), get_ticker_value(), and rates() logic to support the URL structure required by [CoinMarketCap](https://coinmarketcap.com/api/).
  - Not inherently a mandatory change, but it was needed for my implementation of Digibyte, and since CMC has nearly every coin with accurate pricing, the option may be useful to others.
- Updates refresh_ev() to properly set the fiat value of each altcoin.
  - Previously, tip fiat values were reporting as $0.0000 since the confirmation template relies on the fiat value of the coin being present.
- Corrects various stats queries that were failing due to incorrect grouping.
- Ensures opened config files in CointipBot's \_\_init__ are closed after parsing.
  - Otherwise leads to a bug where restarting the bot multiple times will eventually output a "too many open files" error.